### PR TITLE
use golang go-pretty for the table

### DIFF
--- a/cmd/main/demystifier.go
+++ b/cmd/main/demystifier.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/migtools/demystifier/lib/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -136,14 +137,15 @@ func PrintTestSummary(testData *utils.TestRunData) {
 
 	// Print the summary table
 	fmt.Println("Test Summary Table:")
-	headerStr := "---------------------------------------------------------------------------------------------------"
-	fmt.Println(headerStr)
-	fmt.Printf("| %-40s | %-15s | %-11s | %-20s |\n", "Test Name", "Num Attempts", "Num Failed", "Average Run Time")
-	fmt.Println(headerStr)
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.AppendHeader(table.Row{"Test Name", "Num Attempts", "Num Failed", "Average Run Time"})
 	for _, summary := range summaries {
-		fmt.Printf("| %-40s | %-15d | %-11d | %-20s |\n", summary.Name, summary.NumAttempts, summary.NumFailed, summary.AverageRunTime)
+		t.AppendRows([]table.Row{
+			{summary.Name, summary.NumAttempts, summary.NumFailed, summary.AverageRunTime},
+		})
 	}
-	fmt.Println(headerStr)
+	t.Render()
 }
 
 func main() {

--- a/cmd/main/test_summary_test.go
+++ b/cmd/main/test_summary_test.go
@@ -40,42 +40,42 @@ func TestPrintTestSummary(t *testing.T) {
 				logFile: logFile,
 			},
 			want: `Test Summary Table:
----------------------------------------------------------------------------------------------------
-| Test Name                                | Num Attempts    | Num Failed  | Average Run Time     |
----------------------------------------------------------------------------------------------------
-| Should succeed                           | 1               | 0           | 5.044s               |
-| AWS Without Region And S3ForcePathStyle true should fail | 1               | 0           | 20.036s              |
-| Should succeed                           | 1               | 0           | 20.071s              |
-| HTTP_PROXY set                           | 1               | 0           | 35.243s              |
-| NO_PROXY set                             | 1               | 0           | 35.291s              |
-| unsupportedOverrides should succeed      | 1               | 0           | 1m20.133s            |
-| Adding CSI plugin                        | 1               | 0           | 1m20.133s            |
-| Provider plugin                          | 1               | 0           | 1m20.136s            |
-| AWS With Region And S3ForcePathStyle should succeed | 1               | 0           | 1m20.138s            |
-| Adding Velero custom plugin              | 1               | 0           | 1m20.139s            |
-| Set restic node selector                 | 1               | 0           | 1m20.14s             |
-| AWS Without Region No S3ForcePathStyle with BackupImages false should succeed | 1               | 0           | 1m20.141s            |
-| NoDefaultBackupLocation                  | 1               | 0           | 1m20.141s            |
-| Default velero CR, test carriage return  | 1               | 0           | 1m20.141s            |
-| Default velero CR                        | 1               | 0           | 1m20.142s            |
-| DPA CR with bsl and vsl                  | 1               | 0           | 1m20.143s            |
-| Enable tolerations                       | 1               | 0           | 1m20.148s            |
-| Adding Velero resource allocations       | 1               | 0           | 1m20.153s            |
-| Default velero CR with restic disabled   | 1               | 0           | 1m20.172s            |
-| HTTPS_PROXY set                          | 1               | 0           | 2m5.099s             |
-| Mongo application KOPIA                  | 1               | 0           | 2m31.823s            |
-| MySQL application KOPIA                  | 1               | 0           | 2m36.65s             |
-| MySQL application RESTIC                 | 1               | 0           | 2m46.649s            |
-| Mongo application RESTIC                 | 1               | 0           | 2m51.694s            |
-| MySQL application CSI                    | 2               | 1           | 3m8.943s             |
-| Config unset                             | 1               | 0           | 3m31.199s            |
-| Mongo application CSI                    | 1               | 0           | 3m36.749s            |
-| MySQL application DATAMOVER              | 1               | 0           | 4m16.949s            |
-| Mongo application DATAMOVER              | 1               | 0           | 4m17.239s            |
-| Mongo application DATAMOVER              | 1               | 0           | 4m36.933s            |
-| Mongo application BlockDevice DATAMOVER  | 1               | 0           | 5m6.999s             |
-| MySQL application two Vol CSI            | 3               | 3           | 6m16.036s            |
----------------------------------------------------------------------------------------------------
++-------------------------------------------------------------------------------+--------------+------------+------------------+
+| TEST NAME                                                                     | NUM ATTEMPTS | NUM FAILED | AVERAGE RUN TIME |
++-------------------------------------------------------------------------------+--------------+------------+------------------+
+| Should succeed                                                                |            1 |          0 |           5.044s |
+| AWS Without Region And S3ForcePathStyle true should fail                      |            1 |          0 |          20.036s |
+| Should succeed                                                                |            1 |          0 |          20.071s |
+| HTTP_PROXY set                                                                |            1 |          0 |          35.243s |
+| NO_PROXY set                                                                  |            1 |          0 |          35.291s |
+| unsupportedOverrides should succeed                                           |            1 |          0 |        1m20.133s |
+| Adding CSI plugin                                                             |            1 |          0 |        1m20.133s |
+| Provider plugin                                                               |            1 |          0 |        1m20.136s |
+| AWS With Region And S3ForcePathStyle should succeed                           |            1 |          0 |        1m20.138s |
+| Adding Velero custom plugin                                                   |            1 |          0 |        1m20.139s |
+| Set restic node selector                                                      |            1 |          0 |         1m20.14s |
+| AWS Without Region No S3ForcePathStyle with BackupImages false should succeed |            1 |          0 |        1m20.141s |
+| NoDefaultBackupLocation                                                       |            1 |          0 |        1m20.141s |
+| Default velero CR, test carriage return                                       |            1 |          0 |        1m20.141s |
+| Default velero CR                                                             |            1 |          0 |        1m20.142s |
+| DPA CR with bsl and vsl                                                       |            1 |          0 |        1m20.143s |
+| Enable tolerations                                                            |            1 |          0 |        1m20.148s |
+| Adding Velero resource allocations                                            |            1 |          0 |        1m20.153s |
+| Default velero CR with restic disabled                                        |            1 |          0 |        1m20.172s |
+| HTTPS_PROXY set                                                               |            1 |          0 |         2m5.099s |
+| Mongo application KOPIA                                                       |            1 |          0 |        2m31.823s |
+| MySQL application KOPIA                                                       |            1 |          0 |         2m36.65s |
+| MySQL application RESTIC                                                      |            1 |          0 |        2m46.649s |
+| Mongo application RESTIC                                                      |            1 |          0 |        2m51.694s |
+| MySQL application CSI                                                         |            2 |          1 |         3m8.943s |
+| Config unset                                                                  |            1 |          0 |        3m31.199s |
+| Mongo application CSI                                                         |            1 |          0 |        3m36.749s |
+| MySQL application DATAMOVER                                                   |            1 |          0 |        4m16.949s |
+| Mongo application DATAMOVER                                                   |            1 |          0 |        4m17.239s |
+| Mongo application DATAMOVER                                                   |            1 |          0 |        4m36.933s |
+| Mongo application BlockDevice DATAMOVER                                       |            1 |          0 |         5m6.999s |
+| MySQL application two Vol CSI                                                 |            3 |          3 |        6m16.036s |
++-------------------------------------------------------------------------------+--------------+------------+------------------+
 `,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,9 @@ go 1.21.4
 
 require github.com/sirupsen/logrus v1.9.3
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+require (
+	github.com/jedib0t/go-pretty/v6 v6.5.8 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,14 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jedib0t/go-pretty/v6 v6.5.8 h1:8BCzJdSvUbaDuRba4YVh+SKMGcAAKdkcF3SVFbrHAtQ=
+github.com/jedib0t/go-pretty/v6 v6.5.8/go.mod h1:zbn98qrYlh95FIhwwsbIip0LYpwSG8SUOScs+v9/t0E=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -10,6 +16,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
go-pretty much like python makes a autosized table that looks a bit nicer

```
Test Summary Table:
+-------------------------------------------------------------------------------+--------------+------------+------------------+
| TEST NAME                                                                     | NUM ATTEMPTS | NUM FAILED | AVERAGE RUN TIME |
+-------------------------------------------------------------------------------+--------------+------------+------------------+
| Should succeed                                                                |            1 |          0 |           5.044s |
| AWS Without Region And S3ForcePathStyle true should fail                      |            1 |          0 |          20.036s |
| Should succeed                                                                |            1 |          0 |          20.071s |
| HTTP_PROXY set                                                                |            1 |          0 |          35.243s |
| NO_PROXY set                                                                  |            1 |          0 |          35.291s |
| unsupportedOverrides should succeed                                           |            1 |          0 |        1m20.133s |
| Adding CSI plugin                                                             |            1 |          0 |        1m20.133s |
| Provider plugin                                                               |            1 |          0 |        1m20.136s |
| AWS With Region And S3ForcePathStyle should succeed                           |            1 |          0 |        1m20.138s |
| Adding Velero custom plugin                                                   |            1 |          0 |        1m20.139s |
| Set restic node selector                                                      |            1 |          0 |         1m20.14s |
| AWS Without Region No S3ForcePathStyle with BackupImages false should succeed |            1 |          0 |        1m20.141s |
| NoDefaultBackupLocation                                                       |            1 |          0 |        1m20.141s |
| Default velero CR, test carriage return                                       |            1 |          0 |        1m20.141s |
| Default velero CR                                                             |            1 |          0 |        1m20.142s |
| DPA CR with bsl and vsl                                                       |            1 |          0 |        1m20.143s |
| Enable tolerations                                                            |            1 |          0 |        1m20.148s |
| Adding Velero resource allocations                                            |            1 |          0 |        1m20.153s |
| Default velero CR with restic disabled                                        |            1 |          0 |        1m20.172s |
| HTTPS_PROXY set                                                               |            1 |          0 |         2m5.099s |
| Mongo application KOPIA                                                       |            1 |          0 |        2m31.823s |
| MySQL application KOPIA                                                       |            1 |          0 |         2m36.65s |
| MySQL application RESTIC                                                      |            1 |          0 |        2m46.649s |
| Mongo application RESTIC                                                      |            1 |          0 |        2m51.694s |
| MySQL application CSI                                                         |            2 |          1 |         3m8.943s |
| Config unset                                                                  |            1 |          0 |        3m31.199s |
| Mongo application CSI                                                         |            1 |          0 |        3m36.749s |
| MySQL application DATAMOVER                                                   |            1 |          0 |        4m16.949s |
| Mongo application DATAMOVER                                                   |            1 |          0 |        4m17.239s |
| Mongo application DATAMOVER                                                   |            1 |          0 |        4m36.933s |
| Mongo application BlockDevice DATAMOVER                                       |            1 |          0 |         5m6.999s |
| MySQL application two Vol CSI                                                 |            3 |          3 |        6m16.036s |
+-------------------------------------------------------------------------------+--------------+------------+------------------+

```
